### PR TITLE
refactor de demos completo

### DIFF
--- a/app/src/main/java/com/example/tpo_desa_1/config/AppConfig.kt
+++ b/app/src/main/java/com/example/tpo_desa_1/config/AppConfig.kt
@@ -1,0 +1,5 @@
+package com.example.tpo_desa_1.config
+
+object AppConfig {
+    const val ENABLE_DEMO_SEEDING = true
+}

--- a/app/src/main/java/com/example/tpo_desa_1/data/db/RecetaDao.kt
+++ b/app/src/main/java/com/example/tpo_desa_1/data/db/RecetaDao.kt
@@ -9,6 +9,12 @@ interface RecetaDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertar(receta: Receta)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertarTodas(recetas: List<Receta>)
+
+    @Query("DELETE FROM recetas")
+    suspend fun borrarTodas()
+
     @Query("SELECT * FROM recetas WHERE nombre = :nombre")
     suspend fun obtenerPorNombre(nombre: String): Receta?
 
@@ -27,6 +33,7 @@ interface RecetaDao {
     @Query("SELECT * FROM recetas WHERE alias = :alias")
     suspend fun obtenerRecetasPorUsuario(alias: String): List<Receta>
 
-    //@Query("SELECT * FROM recetas WHERE emailUsuario = :email")
-    //suspend fun obtenerRecetasGuardadas(email: String): List<Receta>
+    // Guardado de recetas futuras (comentado por ahora)
+    // @Query("SELECT * FROM recetas WHERE emailUsuario = :email")
+    // suspend fun obtenerRecetasGuardadas(email: String): List<Receta>
 }

--- a/app/src/main/java/com/example/tpo_desa_1/data/db/UsuarioDao.kt
+++ b/app/src/main/java/com/example/tpo_desa_1/data/db/UsuarioDao.kt
@@ -5,9 +5,13 @@ import com.example.tpo_desa_1.data.model.Usuario
 
 @Dao
 interface UsuarioDao {
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertar(usuario: Usuario)
 
     @Query("SELECT * FROM usuarios WHERE (alias = :identificador OR email = :identificador) AND password = :password")
     suspend fun login(identificador: String, password: String): Usuario?
+
+    @Query("SELECT * FROM usuarios WHERE alias = :alias LIMIT 1")
+    suspend fun obtenerPorAlias(alias: String): Usuario?
 }

--- a/app/src/main/java/com/example/tpo_desa_1/data/demo/DemoUsuarios.kt
+++ b/app/src/main/java/com/example/tpo_desa_1/data/demo/DemoUsuarios.kt
@@ -2,7 +2,7 @@ package com.example.tpo_desa_1.data.demo
 
 import com.example.tpo_desa_1.data.model.Usuario
 
-val usuarioDemo = Usuario(
+val demoUsuario = Usuario(
     email = "melina.dumas@parisian.com",
     alias = "MelinaD",
     password = "1234"

--- a/app/src/main/java/com/example/tpo_desa_1/viewmodel/RecetaViewModel.kt
+++ b/app/src/main/java/com/example/tpo_desa_1/viewmodel/RecetaViewModel.kt
@@ -4,19 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.tpo_desa_1.data.model.Receta
 import com.example.tpo_desa_1.repository.RecetaRepository
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.State
-import com.example.tpo_desa_1.data.demo.demoRecetas
-
 
 class RecetaViewModel(
-    private val repository: RecetaRepository,
-    loadDemo: Boolean = false
+    private val repository: RecetaRepository
 ) : ViewModel() {
 
     private val _recetas = mutableStateOf<List<Receta>>(emptyList())
@@ -28,21 +21,7 @@ class RecetaViewModel(
     val recetasAprobadas: State<List<Receta>> = _recetasAprobadas
 
     init {
-        if (loadDemo) {
-            cargarDemo()
-        } else {
-            cargarRecetas()
-        }
-    }
-
-    private fun cargarDemo() {
-        viewModelScope.launch {
-            // Solo guarda si aún no están
-            demoRecetas.forEach { receta ->
-                repository.cargarRecetasEnBase(receta)
-            }
-            cargarRecetas()
-        }
+        cargarRecetas()
     }
 
     fun cargarRecetas() {
@@ -62,5 +41,4 @@ class RecetaViewModel(
             _recetasAprobadas.value = repository.obtenerTodasAprobadas()
         }
     }
-
 }

--- a/app/src/main/java/com/example/tpo_desa_1/viewmodel/RecetaViewModelFactory.kt
+++ b/app/src/main/java/com/example/tpo_desa_1/viewmodel/RecetaViewModelFactory.kt
@@ -10,7 +10,7 @@ class RecetaViewModelFactory(
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(RecetaViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return RecetaViewModel(repository, loadDemo = true) as T
+            return RecetaViewModel(repository) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }


### PR DESCRIPTION
## 🎯 Descripción del Pull Request

### 🧩 Refactor general en la lógica de carga de datos de demo

Se migró la lógica de carga de datos de demo (`demoRecetas` y `demoUsuario`) desde los `ViewModel` hacia la capa de base de datos (`AppDatabase.kt`), con el objetivo de centralizar el seeding y simplificar el flujo de desarrollo.

---

## ✅ Cambios realizados

- Se agregó la clase `AppConfig.kt` con el flag `ENABLE_DEMO_SEEDING` para controlar la activación o desactivación del seeding de demo.
- Se modificó `AppDatabase.kt` para:
  - Ejecutar el seeding en `onOpen` cada vez que se abre la app.
  - Si `ENABLE_DEMO_SEEDING` está activo:
    - Se borran todas las recetas existentes (`recetaDao.borrarTodas()`).
    - Se insertan nuevamente las `demoRecetas`.
    - Se inserta el `demoUsuario` si no existe.
- Se eliminaron los métodos `loadDemo` y la lógica asociada desde `RecetaViewModel` y su `Factory`.
- Ya no es necesario cambiar la versión de la base de datos ni reinstalar la app para ver los cambios en los datos de demo.

---

## 🚀 Resultado

- Cambiar `demoRecetas` o `demoUsuario` se refleja automáticamente al hacer **Run App**.
- La lógica de demo quedó completamente encapsulada en la base de datos.
- Se puede desactivar el modo demo con solo cambiar el valor de `AppConfig.ENABLE_DEMO_SEEDING`.
- Mejora la experiencia de desarrollo, testing y demostración.

---

## 🔧 Archivos modificados

- `AppDatabase.kt`
- `AppConfig.kt` (nuevo)
- `RecetaViewModel.kt`
- `RecetaViewModelFactory.kt`
